### PR TITLE
Piping and console editing support

### DIFF
--- a/app.js
+++ b/app.js
@@ -189,13 +189,11 @@ function loadFile() {
       return false;
     }
   }
-  if(!content){
-  if (!fs.existsSync(filename)) {
+  if (!filename || !fs.existsSync(filename)) {
     return false;
     } else {
       // Emoji-safe split by character (split('') is not safe)
       content = fs.readFileSync(filename, 'utf8').split('\n').map(line => [...line]);
-    }
   }
   if (!content.length) {
     content.push([]);

--- a/app.js
+++ b/app.js
@@ -93,12 +93,13 @@ stdin.on('keypress', (c, k) => {
       // ignore occasional undefined keys on mac
       return;
     }
-    if (k.shift) {
-      k.name = `shift-${k.name}`;
-    }
-    if (k.ctrl) {
-      k.name = `control-${k.name}`;
-    }
+    let prefix = '';
+    if (k.ctrl) prefix += 'control-';
+    if (k.meta) prefix += 'meta-';
+    if (k.shift) prefix += 'shift-';
+
+    k.name = prefix + k.name;
+
     if ((k.sequence.charCodeAt(0) === 27) && (k.sequence.charCodeAt(1) === 27)) {
       // readline isn't quite smart enough on its own to do the right thing if
       // ESC is followed quickly by an arrow key, but gives us enough information

--- a/app.js
+++ b/app.js
@@ -193,9 +193,8 @@ function newFile() {
 }
 
 function saveFile() {
-  if(argv.stdout)
-    console.log(getText(editor.chars));
-  else
+  if(argv.stdout && filename == null)
+    return;
   fs.writeFileSync(filename, getText(editor.chars));
 }
 
@@ -206,7 +205,7 @@ function getText(chars) {
 async function closeEditor() {
   if(argv.stdout){
     stdout.write(ansi.clearScreen);
-    saveFile();
+    console.log(getText(editor.chars));
     process.exit(0);
   }
 

--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@
 
 import fs from 'fs';
 import readline from 'readline';
-import properLockFile from 'proper-lockfile';
 import ansi from 'ansi-escapes';
 import boring from 'boring';
 import { inspect } from 'util';
@@ -42,8 +41,7 @@ fs.mkdirSync(stateFolder, { recursive: true });
 const logFile = fs.createWriteStream(`${stateFolder}/log.txt`, 'utf8');
 
 const clipboard = clipboardFactory({
-  stateFolder,
-  lock
+  stateFolder
 });
 
 const hintStack = [
@@ -169,19 +167,6 @@ function log(...args) {
     }
     logFile.write(arg + '\n');
   }
-}
-
-function lock(filename) {
-  return properLockFile(filename, {
-    retries: {
-      retries: 30,
-      factor: 1,
-      minTimeout: 1000,
-      maxTimeout: 1000
-    },
-    // Avoid chicken and egg problem when the file does not exist yet
-    realpath: false
-  });
 }
 
 function loadFile() {

--- a/app.js
+++ b/app.js
@@ -207,7 +207,7 @@ function newFile() {
 }
 
 function saveFile() {
-  if(argv.stdout && filename == null)
+  if(argv.stdout && (filename == null || !fs.existsSync(filename)))
     return;
   fs.writeFileSync(filename, getText(editor.chars));
 }

--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const tabSpaces = 2;
 const argv = boring();
 
 const filename = argv._[0];
+argv.stdout = argv.stdout || !!argv._[1];
 
 const stdin = process.stdin;
 let stdout;
@@ -150,6 +151,9 @@ while (true) {
 }
 
 function shortFilename(prompt) {
+  if (!filename) {
+    return '<stdout>';
+  }
   return filename.split('/').pop().substring(0, stdout.columns - (prompt || '').length - 5);
 }
 
@@ -176,11 +180,23 @@ function log(...args) {
 }
 
 function loadFile() {
+  let content;
+  if(argv.stdout) {
+    if(!!argv._[1]) {
+      content = argv._[1].split('\n').map(line => [...line]);
+    }
+    if(!filename && !content) {
+      return false;
+    }
+  }
+  if(!content){
   if (!fs.existsSync(filename)) {
     return false;
+    } else {
+      // Emoji-safe split by character (split('') is not safe)
+      content = fs.readFileSync(filename, 'utf8').split('\n').map(line => [...line]);
+    }
   }
-  // Emoji-safe split by character (split('') is not safe)
-  const content = fs.readFileSync(filename, 'utf8').split('\n').map(line => [...line]);
   if (!content.length) {
     content.push([]);
   }
@@ -252,6 +268,9 @@ function resize() {
 }
 
 function guessLanguage(filename) {
+  if(!filename) {
+    return languages.default;
+  }
   const matches = filename.match(/\.([^\.]+)$/);
   if (matches) {
     const found = Object.values(languages).find(language => language.extensions.includes(matches[1]));

--- a/app.js
+++ b/app.js
@@ -151,7 +151,7 @@ while (true) {
 }
 
 function shortFilename(prompt) {
-  if (!filename) {
+  if (!filename || (argv.stdout && !fs.existsSync(filename))) {
     return '<stdout>';
   }
   return filename.split('/').pop().substring(0, stdout.columns - (prompt || '').length - 5);

--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ const tabSpaces = 2;
 const argv = boring();
 
 const filename = argv._[0];
-argv.stdout = argv.stdout || !!argv._[1];
+argv.stdout = argv.stdout || !!argv._[1] || !process.stdout.isTTY;
 
 const stdin = process.stdin;
 let stdout;
@@ -35,7 +35,10 @@ const screen = new Screen({
   log
 });
 
-if (!argv.stdout && !filename && !argv['debug-keycodes']) {
+if ((!argv.stdout && !filename && !argv['debug-keycodes']) || (argv.stdout && !process.stderr.isTTY)) {
+  if(argv.stdout && !process.stderr.isTTY) {
+    process.stderr.write('Error: Unable to display editor UI over stderr. When piping or using --stdout, stderr must be a TTY.\n\n');
+  }
   usage();
 }
 

--- a/bin/tome.sh
+++ b/bin/tome.sh
@@ -6,9 +6,19 @@ scriptroot=$(dirname "$(realpath "$0")")
 # Resolve path to the real tome executable (avoid recursion)
 real_tome="$scriptroot/tome.js"
 
-# Detect presence of --stdout among arguments
-if [[ " $* " == *" --stdout "* ]]; then
-  exec "$real_tome" "$@" 2>/dev/tty
+# Detect presence of --stdout among arguments and handle stdin accordingly
+if [ -t 0 ]; then
+    if [[ " $* " == *" --stdout "* ]]; then
+        exec "$real_tome" "$1" 2>/dev/tty
+    else
+        exec "$real_tome" "$1"
+    fi
 else
-  exec "$real_tome" "$@"
+    input_data=$(cat)
+    if [[ " $* " == *" --stdout "* ]]; then
+        exec "$real_tome" "$1" "$input_data" 2>/dev/tty < /dev/tty
+    else
+        exec "$real_tome" "$1" "$input_data" < /dev/tty
+    fi
 fi
+

--- a/bin/tome.sh
+++ b/bin/tome.sh
@@ -1,21 +1,31 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 scriptroot=$(dirname "$(realpath "$0")")
-
-# Resolve path to the real tome executable (avoid recursion)
 real_tome="$scriptroot/tome.js"
+
+case " $* " in
+  *" --stdout "*) has_stdout=1 ;;
+  *) has_stdout=0 ;;
+esac
+
+args=
+for arg in "$@"; do
+  [ "$arg" = "--stdout" ] || args="$args \"$arg\""
+done
+
+eval "set -- $args"
 
 # Detect presence of --stdout among arguments and handle stdin accordingly
 if [ -t 0 ]; then
-    if [[ " $* " == *" --stdout "* ]]; then
-        exec "$real_tome" "$1" 2>/dev/tty
+    if [ "$has_stdout" -eq 1 ]; then
+        exec "$real_tome" "$1" --stdout 2>/dev/tty
     else
         exec "$real_tome" "$1"
     fi
 else
     input_data=$(cat)
-    if [[ " $* " == *" --stdout "* ]]; then
-        exec "$real_tome" "$1" "$input_data" 2>/dev/tty < /dev/tty
+    if [ "$has_stdout" -eq 1 ]; then
+        exec "$real_tome" "$1" "$input_data" --stdout 2>/dev/tty < /dev/tty
     else
         exec "$real_tome" "$1" "$input_data" < /dev/tty
     fi

--- a/bin/tome.sh
+++ b/bin/tome.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# ~/.local/bin/tome  (make sure this directory precedes the real one in PATH)
+
+scriptroot=$(dirname "$(realpath "$0")")
+
+# Resolve path to the real tome executable (avoid recursion)
+real_tome="$scriptroot/tome.js"
+
+# Detect presence of --stdout among arguments
+if [[ " $* " == *" --stdout "* ]]; then
+  exec "$real_tome" "$@" 2>/dev/tty
+else
+  exec "$real_tome" "$@"
+fi

--- a/bin/tome.sh
+++ b/bin/tome.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# ~/.local/bin/tome  (make sure this directory precedes the real one in PATH)
 
 scriptroot=$(dirname "$(realpath "$0")")
 

--- a/clipboard.js
+++ b/clipboard.js
@@ -1,10 +1,22 @@
 "use strict";
 
 import fs from 'fs';
+import properLockFile from 'proper-lockfile';
 
 export default ({
   stateFolder,
-  lock
+  lock = function lock(filename) {
+    return properLockFile(filename, {
+      retries: {
+        retries: 30,
+        factor: 1,
+        minTimeout: 1000,
+        maxTimeout: 1000
+      },
+      // Avoid chicken and egg problem when the file does not exist yet
+      realpath: false
+    });
+  }
 }) => {
   const clipboardFile = `${stateFolder}/clipboard.json`;
   const clipboardLockFile = `${clipboardFile}.lock`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@boutell/tome",
-  "version": "0.4.1",
+  "version": "0.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@boutell/tome",
-      "version": "0.4.1",
+      "version": "0.13.1",
       "license": "GPLv3",
       "dependencies": {
         "ansi-escapes": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/boutell/tome/issues"
   },
   "bin": {
-    "tome": "./bin/tome.js"
+    "tome": "./bin/tome.sh"
   },
   "homepage": "https://github.com/boutell/tome#readme",
   "dependencies": {

--- a/screen.js
+++ b/screen.js
@@ -35,8 +35,8 @@ export default class Screen {
   }
   allocate() {
     const data = [];
-    this.width = process.stdout.columns;
-    this.height = process.stdout.rows;
+    this.width = this.stdout.columns;
+    this.height = this.stdout.rows;
     for (let row = 0; (row < this.height); row++) {
       const cells = [];
       for (let col = 0; (col < this.width); col++) {


### PR DESCRIPTION
This PR attempts to add a much more clever alternative to [`vipe`](https://manpages.ubuntu.com/manpages/jammy/man1/vipe.1.html)

`vipe` (and many similar solutions) use temp files for interactive handling of stdin and stdout in bash/shell scripts. This has an unnecessary footprint of relying on the file system to temporarily buffer stdin so that it can be edited before being sent back to stdout.

This PR attempts to achieve the goal of vipe without that unnecessary footprint, and does so by taking advantage of the 3rd stdio stream: stderr.

Currently, tome uses stdout for rendering, which makes it un-useful for piping (piping controls stdin and stdout), _but if we swap the stdout and stderr streams, we can get an interactive UI while still being able to pipe outputs in a shell script._

To test this change:

```bash
git clone https://github.com/anonhostpi/tome
cd tome

npm install -g .

touch real.js

# works as before
tome real.js

# piping now works
tome real.js --stdout > copy.js

# piping is inferred when receiving stdin:
echo "abcd" | tome real.js > copy.js # contents of real.js are preferred, if it exists, otherwise...
echo "abcd" | tome fake.js > copy2.js # contents of stdin is used

# edited file content can also now be captured by variables for automation scripts (very handy):
a=$(tome real.js --stdout)
echo $a # dumps the new real.js
```

NOTE 1: Specifying a fake file such as fake.js is used effectively only for language detection during pipes

NOTE 2: When piping and pressing control+q, the editor does not autosave nor prompt to save. Saving is still possible, but must be done so manually and _can only be done for existing files_ (no-ops otherwise when piping)